### PR TITLE
Fixing #19 by refining impl parsing.

### DIFF
--- a/src/traceable_node.rs
+++ b/src/traceable_node.rs
@@ -166,8 +166,8 @@ impl RustTraceableNode {
     /// Constructs a new RTN from an IMPL SyntaxNode.
     ///
     /// Constructs a new RustTraceableNode from a given ra_ap_syntax SyntaxNode of IMPL SyntaxKind.
-    /// The impl node is searched for path nodes, defining which struct is being implemented for,
-    /// and optionally which trait is being implemented.
+    /// The impl node is searched for path nodes and ref nodes, defining which struct is being
+    /// implemented for, and optionally which trait is being implemented.
     /// This information is converted to context data that can be used while parsing enclosed nodes.
     ///
     /// ### Parameters
@@ -176,11 +176,33 @@ impl RustTraceableNode {
     /// ### Returns
     /// Some RustTraceableNode if parsing was sucessful, None otherwise.
     fn from_impl_node(node: &SyntaxNode) -> Option<Self> {
+        /*
+        Impl nodes can take different forms.
+
+        - impl [Path]
+        - impl [Path] for [Path]
+        - impl [Path] for [Ref]
+         */
+
         // Get target (the struct the impl is for) and optional trait that gets implemented.
         let path_nodes = node.get_children_kind(SyntaxKind::PATH_TYPE);
+        let ref_nodes = node.get_children_kind(SyntaxKind::REF_TYPE);
 
-        // Either impl STRUCTNAME or impl TRAITNAME for STRUCTNAME.
-        if path_nodes.len() == 2 {
+        // Case: impl [Path]
+        if path_nodes.len() == 1 && ref_nodes.len() == 0 {
+            // Parse to context data.
+            let structref = path_nodes[0].text().to_string();
+            let impl_data = ContextData::new(Context::from_str(&structref), None);
+            let mut new_node = RustTraceableNode::new(
+                "Impl".to_string(),
+                FileReference::new_default(),
+                NodeKind::Context,
+            );
+            new_node.context_data = Some(impl_data);
+            Some(new_node)
+        }
+        // Case: impl [Path] for [Path]
+        else if path_nodes.len() == 2 && ref_nodes.len() == 0 {
             // Expect the for kw to be present when a trait is implemented (2 path nodes).
             let for_kw = node.get_tokens_kind(SyntaxKind::FOR_KW);
             if for_kw.is_empty() {
@@ -198,20 +220,23 @@ impl RustTraceableNode {
                 new_node.context_data = Some(impl_data);
                 Some(new_node)
             }
-        } else if path_nodes.len() == 1 {
-            // Parse to context data.
-            let structref = path_nodes[0].text().to_string();
-            let impl_data = ContextData::new(Context::from_str(&structref), None);
+        }
+        // Case: impl [Path] for [Ref]
+        else if path_nodes.len() == 1 && ref_nodes.len() == 1 {
+            let traitref = path_nodes[0].text().to_string();
+            let structref = ref_nodes[0].text().to_string();
+            let impl_data = ContextData::new(Context::from_str(&structref), Some(traitref));
             let mut new_node = RustTraceableNode::new(
-                "Impl".to_string(),
-                FileReference::new_default(),
-                NodeKind::Context,
-            );
-            new_node.context_data = Some(impl_data);
-            Some(new_node)
-        } else {
-            // No path nodes or 3+, fail parsing.
-            println!("WARNING: Malformed impl node. Continuing...");
+                    "Impl".to_string(),
+                    FileReference::new_default(),
+                    NodeKind::Context,
+                );
+                new_node.context_data = Some(impl_data);
+                Some(new_node)
+        }
+        else {
+            // No matching pattern.
+            println!("WARNING: Non parsable impl node. Continuing...");
             None
         }
     }

--- a/src/traceable_node.rs
+++ b/src/traceable_node.rs
@@ -34,7 +34,8 @@ use json::{object::Object, JsonValue};
 use ra_ap_syntax::{SyntaxKind, SyntaxNode};
 use std::fmt::Display;
 
-use crate::{location::FileReference, syntax_extensions::Searchable, utils::context::Context};
+use crate::{location::FileReference, syntax_extensions::Searchable,
+     utils::context::Context, utils::trait_type_extraction::extract_type_from_trait};
 
 /// Enum to define the different kinds of RustTraceableNodes.
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -119,19 +120,38 @@ impl RustTraceableNode {
     ///
     /// ### Parameters
     /// * `node` - SyntaxNode that should be parsed to a corresponding RTN.
-    /// * `prefix` - Prefix String to prepend to name and tag.
+    /// * `context_data` - ContextData with context and optional trait to prepend to name and tag.
     ///
     /// ### Returns
     /// Some RustTraceableNode if parsing was sucessful, None otherwise.
-    pub(crate) fn from_node(node: &SyntaxNode, prefix: String) -> Option<Self> {
+    pub(crate) fn from_node(node: &SyntaxNode, context_data: Option<ContextData>) -> Option<Self> {
         let location = FileReference::new_default();
+
+        // Extract relevant information from the context data.
+        let prefix;
+        let trait_info;
+        if let Some(cd) = context_data {
+            prefix = cd.context.to_str();
+            trait_info = cd.trait_imp;
+        } else {
+            prefix = "".to_string();
+            trait_info = None;
+        }
+
+        // Add a postfix to functions if trait information containing a type was parsed.
+        let mut trait_postfix = String::new();
+        if let Some(traitstr) = trait_info {
+            if let Some(matched_trait) = extract_type_from_trait(&traitstr) {
+                trait_postfix = matched_trait;
+            }
+        } 
 
         // Node handling is dependent on SyntaxKind of the SyntaxNode.
         if let Some(node_kind) = syntax_kind_to_node_kind(node.kind()) {
             match node_kind {
                 NodeKind::Function => {
                     let name_node = node.get_child_kind(SyntaxKind::NAME)?;
-                    let name = prefix + "." + &name_node.text().to_string();
+                    let name = prefix + "." + &name_node.text().to_string() + &trait_postfix;
                     Some(RustTraceableNode::new(name, location, node_kind))
                 }
                 NodeKind::Source => Some(RustTraceableNode::new(
@@ -209,29 +229,29 @@ impl RustTraceableNode {
                 None
             } else {
                 // Parse to context data.
-                let traitref = path_nodes[0].text().to_string();
-                let structref = path_nodes[1].text().to_string();
-                let impl_data = ContextData::new(Context::from_str(&structref), Some(traitref));
+                let traitpath = path_nodes[0].text().to_string();
+                let structpath = path_nodes[1].text().to_string();
+                let context_data = ContextData::new(Context::from_str(&structpath), Some(traitpath));
                 let mut new_node = RustTraceableNode::new(
                     "Impl".to_string(),
                     FileReference::new_default(),
                     NodeKind::Context,
                 );
-                new_node.context_data = Some(impl_data);
+                new_node.context_data = Some(context_data);
                 Some(new_node)
             }
         }
         // Case: impl [Path] for [Ref]
         else if path_nodes.len() == 1 && ref_nodes.len() == 1 {
-            let traitref = path_nodes[0].text().to_string();
+            let traitpath = path_nodes[0].text().to_string();
             let structref = ref_nodes[0].text().to_string();
-            let impl_data = ContextData::new(Context::from_str(&structref), Some(traitref));
+            let context_data = ContextData::new(Context::from_str(&structref), Some(traitpath));
             let mut new_node = RustTraceableNode::new(
                     "Impl".to_string(),
                     FileReference::new_default(),
                     NodeKind::Context,
                 );
-                new_node.context_data = Some(impl_data);
+                new_node.context_data = Some(context_data);
                 Some(new_node)
         }
         else {
@@ -273,16 +293,16 @@ impl RustTraceableNode {
     /// ### Parameters
     /// * `node` - SyntaxNode that should be parsed to a corresponding RTN.
     /// * `location` - FileReference for the new RTN.
-    /// * `prefix` - Prefix String to prepend to name and tag.
+    /// * `context_data` - ContextData with context and optional trait to prepend to name and tag.
     ///
     /// ### Returns
     /// Some RustTraceableNode if parsing was sucessful, None otherwise.
     pub(crate) fn from_node_with_location(
         node: &SyntaxNode,
         location: FileReference,
-        prefix: String,
+        context_data: Option<ContextData>,
     ) -> Option<Self> {
-        if let Some(mut new_node) = Self::from_node(node, prefix) {
+        if let Some(mut new_node) = Self::from_node(node, context_data) {
             new_node.location = location;
             Some(new_node)
         } else {
@@ -356,7 +376,6 @@ impl From<&RustTraceableNode> for JsonValue {
     ///
     /// ### Returns Json object holding the RTN data in lobser common interchange format.
     fn from(node: &RustTraceableNode) -> JsonValue {
-        // idk if we really want to do this
         let mut json_out = JsonValue::Object(Object::new());
         let _ = json_out.insert("tag", format!("rust {}", node.name));
         let _ = json_out.insert("name", node.name.to_string());
@@ -392,7 +411,7 @@ impl From<&RustTraceableNode> for JsonValue {
 #[derive(Debug, Clone)]
 pub(crate) struct ContextData {
     pub(crate) context: Context,
-    pub(crate) _trait_imp: Option<String>,
+    pub(crate) trait_imp: Option<String>,
 }
 
 impl ContextData {
@@ -406,10 +425,10 @@ impl ContextData {
     ///
     /// ### Returns
     /// The newly constructed context data.
-    fn new(context: Context, trait_imp: Option<String>) -> Self {
+    pub(crate) fn new(context: Context, trait_imp: Option<String>) -> Self {
         ContextData {
             context,
-            _trait_imp: trait_imp,
+            trait_imp,
         }
     }
 }

--- a/src/utils/trait_type_extraction.rs
+++ b/src/utils/trait_type_extraction.rs
@@ -27,11 +27,20 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-//! # Utils
-//!
-//! Collection of different utility functions.
+//! Utility function to extract the type from a trait specification string.
 
-pub(crate) mod context;
-pub(crate) mod extract_path_attr;
-pub(crate) mod module_resolution;
-pub(crate) mod trait_type_extraction;
+use regex::Regex;
+
+pub(crate) fn extract_type_from_trait(trait_str: &String) -> Option<String> {
+    // Extract a possible type that is specified in angle brackets at the end of the trait.
+    // Allow matching of references (&) and lifetimes (') in the angle brackets.
+    let type_re = Regex::new(r".*(?<type><[[:alnum:]\._\-&'\s]+>)").unwrap();
+    
+    if let Some(cap) = type_re.captures(trait_str) {
+        if let Some(typematch) = cap.name("type") {
+            let typestring = typematch.as_str().to_string();
+            return Some(typestring);
+        }
+    }
+    None
+}

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -38,10 +38,8 @@ use std::path::PathBuf;
 use crate::{
     location::FileReference,
     syntax_extensions::{Searchable, Visitable},
-    traceable_node::{NodeKind, RustTraceableNode},
-    utils::context::Context,
-    utils::extract_path_attr::extract_path_attribute,
-    utils::module_resolution::resolve_module_declaration,
+    traceable_node::{ContextData, NodeKind, RustTraceableNode},
+    utils::{context::Context, extract_path_attr::extract_path_attribute, module_resolution::resolve_module_declaration},
 };
 
 /// Visitor trait
@@ -162,7 +160,7 @@ impl RustVisitor {
     /// Combines the Contexts of the context data into one Context.
     ///
     /// ### Returns
-    /// context as a combination of all enclosing Contexts.
+    /// Context as a combination of all enclosing Contexts.
     fn get_enclosing_context(&self) -> Context {
         // Get reference to the implementation data of the latest Impl node.
         let nested_in: Vec<&Context> = self
@@ -178,6 +176,28 @@ impl RustVisitor {
             nested_in.into_iter().sum()
         } else {
             Context::Empty
+        }
+    }
+
+    /// Retreive the most relevant trait data on the stack.
+    /// 
+    /// Traverses the stack to find context nodes that hold trait implementation information.
+    /// Returns the latest trait information on the stack, if any is found.
+    /// 
+    /// ### Returns
+    /// Optional trait information that is on the stack.
+    fn get_enclosing_trait(&self) -> Option<String> {
+        let trait_data_on_stack: Vec<&String> = self.vdata
+        .node_stack.iter().filter(|n| NodeKind::Context == n.kind)
+            .filter_map(|rtn| rtn.context_data.as_ref())
+            .filter_map(|context_data| context_data.trait_imp.as_ref())
+            .collect();
+
+        if let Some(last_trait) = trait_data_on_stack.last() {
+            println!("Got trait: {:#?}", last_trait);
+            Some((*last_trait).clone())
+        } else {
+            None
         }
     }
 
@@ -250,7 +270,7 @@ impl RustVisitor {
     /// ### Parameters
     /// * `source_node` - SyntaxNode of kind SOURCE. Top level node of a source file.
     fn enter_source(&mut self, source_node: &SyntaxNode) {
-        let mut root_node = RustTraceableNode::from_node(source_node, String::new()).unwrap();
+        let mut root_node = RustTraceableNode::from_node(source_node, None).unwrap();
         root_node.name = self.get_filename();
         self.vdata.node_stack.push(root_node);
     }
@@ -271,10 +291,13 @@ impl RustVisitor {
 
         // Check for enclosing context.
         let context = &self.default_context + self.get_filename() + self.get_enclosing_context();
+        let trait_info: Option<String> = self.get_enclosing_trait();
+
+        let context_data = ContextData::new(context, trait_info);
 
         // Parse node.
         if let Some(node) =
-            RustTraceableNode::from_node_with_location(fn_node, location, context.to_str())
+            RustTraceableNode::from_node_with_location(fn_node, location, Some(context_data))
         {
             self.vdata.node_stack.push(node);
         }
@@ -314,10 +337,11 @@ impl RustVisitor {
 
         // Check for enclosing context.
         let context = &self.default_context + self.get_filename() + self.get_enclosing_context();
+        let context_data = ContextData::new(context, None);
 
         // Parse node.
         if let Some(node) =
-            RustTraceableNode::from_node_with_location(struct_node, location, context.to_str())
+            RustTraceableNode::from_node_with_location(struct_node, location, Some(context_data))
         {
             self.vdata.node_stack.push(node);
         }
@@ -348,7 +372,7 @@ impl RustVisitor {
     /// ### Parameters
     /// * `impl_node` - SyntaxNode of kind IMPL.
     fn enter_impl(&mut self, impl_node: &SyntaxNode) {
-        let node = RustTraceableNode::from_node(impl_node, String::new()).unwrap();
+        let node = RustTraceableNode::from_node(impl_node, None).unwrap();
         self.vdata.node_stack.push(node);
     }
 
@@ -410,7 +434,7 @@ impl RustVisitor {
                 if n.kind() == SyntaxKind::ITEM_LIST {
                     // Found local module. Parse as Context.
                     let context_node =
-                        RustTraceableNode::from_node(mod_node, String::new()).unwrap();
+                        RustTraceableNode::from_node(mod_node, None).unwrap();
                     self.vdata.node_stack.push(context_node);
                 }
             }
@@ -445,7 +469,7 @@ impl RustVisitor {
     /// * `trait_node` - SyntaxNode of kind Trait.
     fn enter_trait(&mut self, trait_node: &SyntaxNode) {
         // The node information is not needed for the output, only for context while parsing.
-        let traceable_trait_node = RustTraceableNode::from_node(trait_node, String::new()).unwrap();
+        let traceable_trait_node = RustTraceableNode::from_node(trait_node, None).unwrap();
         self.vdata.node_stack.push(traceable_trait_node);
     }
 


### PR DESCRIPTION
Also extracting type from type specific trait implementations.

For example the + operator can be extended by implemeting ops::Add<Type>.
This type is now extracted and added as a postfix, so the funxtion will be named .add<Type>.

This removes the obscurity when implemeting the trait for multiple types.